### PR TITLE
Fix flake8 execution

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 160

--- a/app/services/models/models.py
+++ b/app/services/models/models.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-import os
+from pathlib import Path
 from typing import List
 
-from pydantic import UUID1
-from sqlalchemy import Column, Integer, String, create_engine, DateTime, Date, JSON, UUID
+from decouple import AutoConfig
+from sqlalchemy import JSON, UUID, Column, Date, Integer, String, create_engine
 from sqlalchemy.dialects.postgresql import BYTEA
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import declarative_base, sessionmaker
-
-from pathlib import Path
-
-from decouple import Config, RepositoryEnv, AutoConfig
 
 # Base directory of the project (two levels up from this file)
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -27,6 +23,7 @@ config = AutoConfig(search_path=BASE_DIR)
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _build_database_url() -> str:
     """
@@ -46,12 +43,16 @@ def _build_database_url() -> str:
         return db_url  # already complete
 
     # 2️⃣ Assemble from individual settings in .env
-    required_keys: List[str] = ["DB_USER", "DB_PASSWORD", "DB_HOST", "DB_PORT", "DB_NAME"]
+    required_keys: List[str] = [
+        "DB_USER",
+        "DB_PASSWORD",
+        "DB_HOST",
+        "DB_PORT",
+        "DB_NAME",
+    ]
     missing = [key for key in required_keys if not config(key, default="")]
     if missing:
-        raise RuntimeError(
-            f"Missing database variables in .env: {', '.join(missing)}."
-        )
+        raise RuntimeError(f"Missing database variables in .env: {', '.join(missing)}.")
 
     db_user = config("DB_USER")
     db_password = config("DB_PASSWORD")
@@ -59,7 +60,9 @@ def _build_database_url() -> str:
     db_port = config("DB_PORT")
     db_name = config("DB_NAME")
 
-    return f"postgresql+psycopg2://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
+    return (
+        f"postgresql+psycopg2://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -94,6 +97,7 @@ class Conversation(Base):
     message = Column(String, nullable=False)
     response = Column(String)
 
+
 class Patient(Base):
     __tablename__ = "patient"
     patient_id = Column(UUID, primary_key=True, index=True)
@@ -102,5 +106,3 @@ class Patient(Base):
     phone_e164 = Column(String, nullable=False)
     email = Column(String, nullable=True)
     address_json = Column(JSON, nullable=True)
-
-

--- a/app/services/secure_storage.py
+++ b/app/services/secure_storage.py
@@ -1,11 +1,13 @@
 """Utility for storing conversations in the database."""
+
+import uuid
 from datetime import date
-import uuid,json
 from typing import Any
+
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from .models.models import Conversation, SessionLocal, Patient
+from .models.models import Conversation, Patient, SessionLocal
 
 
 def store_conversation(
@@ -36,13 +38,14 @@ def store_conversation(
 
 
 def store_patient(
-        patient_id: uuid.UUID | str,
-        full_name: bytes,
-        date_of_birth: date,
-        phone_e164: str,
-        email: str | None,
-        address_json: dict[str, Any] | str,
-        db:Session | None = None) -> uuid.UUID:
+    patient_id: uuid.UUID | str,
+    full_name: bytes,
+    date_of_birth: date,
+    phone_e164: str,
+    email: str | None,
+    address_json: dict[str, Any] | str,
+    db: Session | None = None,
+) -> uuid.UUID:
 
     created_session = False
     if db is None:
@@ -51,8 +54,14 @@ def store_patient(
 
     try:
         id_ = uuid.UUID(str(patient_id))
-        patient = Patient(patient_id = id_, full_name = full_name, date_of_birth = date_of_birth,
-                          phone_e164 = phone_e164, email = email, address_json = address_json)
+        patient = Patient(
+            patient_id=id_,
+            full_name=full_name,
+            date_of_birth=date_of_birth,
+            phone_e164=phone_e164,
+            email=email,
+            address_json=address_json,
+        )
         db.add(patient)
         db.commit()
         db.refresh(patient)
@@ -65,4 +74,3 @@ def store_patient(
     finally:
         if created_session:
             db.close()
-


### PR DESCRIPTION
## Summary
- remove unused imports and tidy medical_intake_agent
- clean up ORM model definitions and secure storage utils
- add flake8 config to relax line length

## Testing
- `poetry run flake8 app/agents/medical_intake_agent.py app/cli_chat_handler.py app/main.py app/services/models/models.py app/services/secure_storage.py app/tests/test_facebook.py app/tests/test_routes.py`
- `PYTHONPATH=. poetry run pytest -q` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_683f8fe658c08322829f371bcda8d5d7