### PR TITLE
Fix PHI storage

### DIFF
--- a/app/agents/medical_intake_agent.py
+++ b/app/agents/medical_intake_agent.py
@@ -1,34 +1,29 @@
 # Add this at the top of your medical_intake_agent.py file
 import uuid
 from typing import Any, Dict, List
-# Global dictionary to store conversation history by user ID
+
+# Global dictionaries to store conversation history and patient IDs by user
 user_conversations: Dict[str, List[Any]] = {}
+user_patient_ids: Dict[str, uuid.UUID] = {}
 import json
 import os
 from datetime import date, datetime
 from pathlib import Path
-from sqlalchemy.orm import Session
-from sqlalchemy.exc import SQLAlchemyError
-from app.services.utils.utils import logger
-from app.services.models.models import SessionLocal
-from app.services.secure_storage import  store_patient
 
-from langchain.agents import (
-    AgentExecutor,
-    AgentType,
-    create_react_agent,
-    initialize_agent,
-)
+from langchain.agents import (AgentExecutor, AgentType, create_react_agent,
+                              initialize_agent)
 from langchain.memory import ConversationBufferMemory
 from langchain.output_parsers import PydanticOutputParser
-from langchain_core.prompts import (
-    ChatPromptTemplate,
-    MessagesPlaceholder,
-    PromptTemplate,
-)
+from langchain_core.prompts import (ChatPromptTemplate, MessagesPlaceholder,
+                                    PromptTemplate)
 from langchain_openai import ChatOpenAI
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
 from app.config import config
+from app.services.models.models import SessionLocal
+from app.services.secure_storage import store_patient
+from app.services.utils.utils import logger
 
 from .schemas.patient_form_EN import PatientHistory
 from .tools_agent.pdf_filler_EN import fill_pdf
@@ -139,21 +134,21 @@ def intake_agent(query: str, user_id: str = "default_user") -> str:
             validated_json = patient_data.model_dump_json(indent=2)
             print(f"Successfully validated patient data against schema")
 
-            #Insert patient's information into database table
+            # Insert patient's information into database table
 
             try:
                 patient_row_id = store_patient(
-           #         patient_id=uuid.UUID(patient_data_dict["patient_id"]),
                     full_name=patient_data_dict["full_name"],
                     date_of_birth=patient_data_dict["dob"],
                     phone_e164=patient_data_dict["phone_e164"],
                     email=patient_data_dict.get("email"),
-                    address_json=patient_data_dict.get("address")
+                    address_json=patient_data_dict.get("address"),
                 )
 
-                logger.info(f"Conversation #{patient_row_id} stored in database")
+                user_patient_ids[user_id] = patient_row_id
+                logger.info(f"Patient {patient_row_id} stored in database")
             except SQLAlchemyError as e:
-                logger.error(f"Error storing conversation in database: {e}")
+                logger.error(f"Error storing patient in database: {e}")
 
             # Clear the conversation history after successful completion
             user_conversations[user_id] = []

--- a/app/cli_chat_handler.py
+++ b/app/cli_chat_handler.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Import the necessary modules
-from .agents.medical_intake_agent import intake_agent
+from .agents.medical_intake_agent import intake_agent, user_patient_ids
 from .services.secure_storage import store_conversation
 from .services.utils.utils import logger
 
@@ -17,15 +17,22 @@ def run_cli_chat():
             break
 
         # Process the input through the medical intake agent
-        response = intake_agent(user_input)
+        response = intake_agent(user_input, user_id="cli_user")
 
-        # Store conversation (optional, can be disabled for quick testing)
-        try:
-            store_conversation("cli_user", user_input, response)
+        if "cli_user" in user_patient_ids:
+            try:
+                store_conversation(
+                    "cli_user",
+                    user_input,
+                    response,
+                    patient_id=user_patient_ids["cli_user"],
+                )
+                print(f"\nMedBot: {response}")
+            except Exception as e:
+                print(f"\nMedBot: {response}")
+                logger.error(f"Error storing CLI conversation: {e}")
+        else:
             print(f"\nMedBot: {response}")
-        except Exception as e:
-            print(f"\nMedBot: {response}")
-            logger.error(f"Error storing CLI conversation: {e}")
 
 
 if __name__ == "__main__":

--- a/app/services/models/models.py
+++ b/app/services/models/models.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
-import os
+from pathlib import Path
 from typing import List
 
-from pydantic import UUID1
-from sqlalchemy import Column, Integer, String, create_engine, DateTime, Date, JSON, UUID
+from decouple import AutoConfig, Config, RepositoryEnv
+from sqlalchemy import (JSON, UUID, Column, Date, DateTime, Integer, String,
+                        create_engine, text)
 from sqlalchemy.dialects.postgresql import BYTEA
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import declarative_base, sessionmaker
-
-from pathlib import Path
-
-from decouple import Config, RepositoryEnv, AutoConfig
 
 # Base directory of the project (two levels up from this file)
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -27,6 +24,7 @@ config = AutoConfig(search_path=BASE_DIR)
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _build_database_url() -> str:
     """
@@ -46,12 +44,16 @@ def _build_database_url() -> str:
         return db_url  # already complete
 
     # 2️⃣ Assemble from individual settings in .env
-    required_keys: List[str] = ["DB_USER", "DB_PASSWORD", "DB_HOST", "DB_PORT", "DB_NAME"]
+    required_keys: List[str] = [
+        "DB_USER",
+        "DB_PASSWORD",
+        "DB_HOST",
+        "DB_PORT",
+        "DB_NAME",
+    ]
     missing = [key for key in required_keys if not config(key, default="")]
     if missing:
-        raise RuntimeError(
-            f"Missing database variables in .env: {', '.join(missing)}."
-        )
+        raise RuntimeError(f"Missing database variables in .env: {', '.join(missing)}.")
 
     db_user = config("DB_USER")
     db_password = config("DB_PASSWORD")
@@ -59,7 +61,9 @@ def _build_database_url() -> str:
     db_port = config("DB_PORT")
     db_name = config("DB_NAME")
 
-    return f"postgresql+psycopg2://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
+    return (
+        f"postgresql+psycopg2://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -90,17 +94,20 @@ class Conversation(Base):
     __tablename__ = "conversations"
 
     id = Column(Integer, primary_key=True, index=True)
+    patient_id = Column(UUID, nullable=True)
     sender = Column(String, nullable=False)
     message = Column(String, nullable=False)
     response = Column(String)
+    created_at = Column(DateTime, server_default=text("now()"))
+
 
 class Patient(Base):
     __tablename__ = "patient"
-    patient_id = Column(UUID, primary_key=True, index=True)
+    patient_id = Column(
+        UUID, primary_key=True, index=True, server_default=text("uuid_generate_v4()")
+    )
     full_name = Column(BYTEA, nullable=False)
     date_of_birth = Column(Date, nullable=False)
     phone_e164 = Column(String, nullable=False)
     email = Column(String, nullable=True)
     address_json = Column(JSON, nullable=True)
-
-

--- a/app/tests/test_facebook.py
+++ b/app/tests/test_facebook.py
@@ -23,7 +23,7 @@ async def override_get_db():
 
 def setup_test(monkeypatch):
     app.dependency_overrides[get_db] = override_get_db
-    monkeypatch.setattr("app.main.intake_agent", lambda body: "ok")
+    monkeypatch.setattr("app.main.intake_agent", lambda *_, **__: "ok")
     monkeypatch.setattr("app.main.fb_send_message", lambda *_, **__: None)
     monkeypatch.setattr("app.main.store_conversation", lambda *_, **__: 1)
 

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -23,7 +23,7 @@ async def override_get_db():
 
 def setup_test(monkeypatch):
     app.dependency_overrides[get_db] = override_get_db
-    monkeypatch.setattr("app.main.intake_agent", lambda body: "ok")
+    monkeypatch.setattr("app.main.intake_agent", lambda *_, **__: "ok")
     monkeypatch.setattr("app.main.fb_send_message", lambda *_, **__: None)
     monkeypatch.setattr("app.main.store_conversation", lambda *_, **__: 1)
 


### PR DESCRIPTION
## Summary
- map user to patient ID when intake form is completed
- add patient_id column and server defaults in models
- store patient and conversation data separately
- adapt CLI and API endpoints to use patient ID mapping
- update tests for new function signatures

## Testing
- `poetry run flake8 app/agents/medical_intake_agent.py app/cli_chat_handler.py app/main.py app/services/models/models.py app/services/secure_storage.py app/tests/test_facebook.py app/tests/test_routes.py`
- `PYTHONPATH=. poetry run pytest -q` *(fails: DATABASE_URL must start with 'postgresql://'. Check the value in your `.env` file.)*

------
https://chatgpt.com/codex/tasks/task_e_683f8680fc1083229b639d017b84b8fb